### PR TITLE
Generated export GBDK compilation fix

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,6 +5,18 @@ This tool was written to help modern gameboy game developers create games easier
 You can download GBDK-2020 [here](https://github.com/gbdk-2020/gbdk-2020)
 You can download RGBDS [here](https://rgbds.gbdev.io/)
 
+# Prerequisites
+
+* node
+* npm
+
+# Build 
+
+```
+npm install
+npm run build
+```
+
 ## Arguments
 
 

--- a/src/utils/export/objects/gbdk-object-export.utils.ts
+++ b/src/utils/export/objects/gbdk-object-export.utils.ts
@@ -37,7 +37,7 @@ const getGBDKObjectHExport = (executionData:ExecutionData)=>{
 
 ${getStructDataString(executionData)}
 
-const ${objectStructName} ${executionData.identifier}Objects[${executionData.totalObjects.length}];
+extern const ${objectStructName} ${executionData.identifier}Objects[${executionData.totalObjects.length}];
 
 ${executionData.objectStrings.map(x=>"const unsigned char *"+x.name+";").join("\n")}`;
 }

--- a/src/utils/export/tilemap/gbdk-tilemap.export.utils.ts
+++ b/src/utils/export/tilemap/gbdk-tilemap.export.utils.ts
@@ -56,8 +56,8 @@ export const getGBDKExportHContents = (
 #define ${executionData.identifier}_WIDTH ${executionData.mapWidth}
 #define ${executionData.identifier}_HEIGHT ${executionData.mapHeight}
 
-const unsigned char ${executionData.identifier}_map[${tileCount}];
-const unsigned char ${executionData.identifier}_map_attributes[${tileCount}] ;
+extern const unsigned char ${executionData.identifier}_map[${tileCount}];
+extern const unsigned char ${executionData.identifier}_map_attributes[${tileCount}] ;
 `;
   return exportHContent;
 };

--- a/src/utils/export/tilemap/gbdk-tilemap.export.utils.ts
+++ b/src/utils/export/tilemap/gbdk-tilemap.export.utils.ts
@@ -31,11 +31,11 @@ export const getGBDKExportCContents = (
 BANKREF(${executionData.identifier})
 
 const unsigned char ${executionData.identifier}_map[${tileCount}] = {
-  ${mappedRows.map(x=>"\t"+x.map(y=>"0x"+y.index.toString(16)).join(", ")).join("\n")}
+  ${mappedRows.map(x=>"\t"+x.map(y=>"0x"+y.index.toString(16)).join(", ")).join(",\n")}
 };
 
 const unsigned char ${executionData.identifier}_map_attributes[${tileCount}] = {
-  ${mappedRowsAttributes.map(x=>"\t"+x.map(y=>"0x"+y.toString(16)).join(", ")).join("\n")}
+  ${mappedRowsAttributes.map(x=>"\t"+x.map(y=>"0x"+y.toString(16)).join(", ")).join(",\n")}
 };
 `;
 


### PR DESCRIPTION
With this PR the generated code can compile without error with GBDK

* There where missing comma in exported array on newline  

```
const unsigned char world1area1_map[360] = {
  	0xff, 0x0, 0x0, ... 0x0, 0x0     <- missing array
...


* Declaration in header as extern 

from `const unsigned char world1area1_map[360];` to `extern const unsigned char world1area1_map[360];`  this fix multiple definition error (It's also how png2asset solve this)